### PR TITLE
 Overwrite HTML5Video inherited methods

### DIFF
--- a/src/hls.js
+++ b/src/hls.js
@@ -253,7 +253,7 @@ export default class HlsjsPlayback extends HTML5Video {
     // assume live if time within 3 seconds of end of stream
     this.dvrEnabled && this._updateDvr(time < this.getDuration()-3)
     time += this._startTime
-    super.seek(time)
+    this.el.currentTime = time
   }
 
   seekToLivePoint() {

--- a/src/hls.js
+++ b/src/hls.js
@@ -410,13 +410,9 @@ export default class HlsjsPlayback extends HTML5Video {
   }
 
   pause() {
-    if (!this._hls)
-      return
-
-    super.pause()
-    if (this.dvrEnabled)
-      this._updateDvr(true)
-
+    if (!this._hls) return
+    this.el.pause()
+    if (this.dvrEnabled) this._updateDvr(true)
   }
 
   stop() {


### PR DESCRIPTION
## Summary

This PR updates `seek` and `pause` methods to overwrite `HTML5Video` Class inherits.

## Changes

* Set the current time on video element when the `seek(time)` method is called;
* Call `videoElement.pause` method when `pause` plugin method is called;

## How to test

All changes in this PR should not impact any use of the `HlsjsPlayback`.