### PR TITLE
Prevent access of invalid references

### DIFF
--- a/src/hls.js
+++ b/src/hls.js
@@ -160,6 +160,7 @@ export default class HlsjsPlayback extends HTML5Video {
   _setup() {
     this._ccIsSetup = false
     this._ccTracksUpdated = false
+    this._hls && this._hls.destroy()
     this._hls = new HLSJS(assign({}, this.options.playback.hlsjsConfig))
     this._hls.once(HLSJS.Events.MEDIA_ATTACHED, () => this._hls.loadSource(this.options.src))
     this._hls.on(HLSJS.Events.LEVEL_LOADED, (evt, data) => this._updatePlaybackType(evt, data))


### PR DESCRIPTION
## Summary

This PR prevents access to one invalid internal `HLS` reference to avoid log noises.

## Changes

* Deletes `HLS` instance before creates a new one;

## How to test

All changes in this PR should not impact any use of the project.