### PR TITLE
Ensure the existence of the HLS.JS internal instance on the ready state

### DIFF
--- a/src/hls.js
+++ b/src/hls.js
@@ -192,6 +192,7 @@ export default class HlsjsPlayback extends HTML5Video {
   }
 
   _ready() {
+    !this._hls && this._setup()
     this._isReadyState = true
     this.trigger(Events.PLAYBACK_READY, this.name)
   }

--- a/src/hls.js
+++ b/src/hls.js
@@ -192,6 +192,7 @@ export default class HlsjsPlayback extends HTML5Video {
   }
 
   _ready() {
+    if (this._isReadyState) return
     !this._hls && this._setup()
     this._isReadyState = true
     this.trigger(Events.PLAYBACK_READY, this.name)

--- a/src/hls.test.js
+++ b/src/hls.test.js
@@ -173,6 +173,41 @@ describe('HlsjsPlayback', () => {
     })
   })
 
+  describe('_ready method', () => {
+    test('call _setup method if HLS.JS internal don\'t exists', () => {
+      const playback = new HlsjsPlayback({ src: 'http://clappr.io/video.m3u8' })
+      jest.spyOn(playback, '_setup')
+      playback._ready()
+
+      expect(playback._setup).toHaveBeenCalledTimes(1)
+
+      playback._ready()
+      expect(playback._setup).toHaveBeenCalledTimes(1)
+    })
+
+    test('update _isReadyState flag value to true', () => {
+      const playback = new HlsjsPlayback({ src: 'http://clappr.io/video.m3u8' })
+
+      expect(playback._isReadyState).toBeFalsy()
+
+      playback._ready()
+
+      expect(playback._isReadyState).toBeTruthy()
+    })
+
+    test('triggers PLAYBACK_READY event', done => {
+      const cb = jest.fn()
+      const playback = new HlsjsPlayback({ src: 'http://clappr.io/video.m3u8' })
+
+      playback.listenTo(playback, Events.PLAYBACK_READY, cb)
+      playback.listenTo(playback, Events.PLAYBACK_READY, () => {
+        expect(cb).toHaveBeenCalledTimes(1)
+        done()
+      })
+      playback._ready()
+    })
+  })
+
   describe('play method', () => {
     test('calls this._hls.loadSource if _manifestParsed flag and options.hlsPlayback.preload are falsy', () => {
       const playback = new HlsjsPlayback({ src: 'http://clappr.io/foo.m3u8', hlsPlayback: { preload: true } })

--- a/src/hls.test.js
+++ b/src/hls.test.js
@@ -174,6 +174,15 @@ describe('HlsjsPlayback', () => {
   })
 
   describe('_ready method', () => {
+    test('avoid to run internal logic if _isReadyState flag is true', () => {
+      const playback = new HlsjsPlayback({ src: 'http://clappr.io/video.m3u8' })
+      playback._isReadyState = true
+      jest.spyOn(playback, '_setup')
+      playback._ready()
+
+      expect(playback._setup).not.toHaveBeenCalled()
+    })
+
     test('call _setup method if HLS.JS internal don\'t exists', () => {
       const playback = new HlsjsPlayback({ src: 'http://clappr.io/video.m3u8' })
       jest.spyOn(playback, '_setup')


### PR DESCRIPTION
#### This PR depends on https://github.com/clappr/hlsjs-playback/pull/15 to don't change the current playback behavior when the `_setup` method is called.

## Summary

In the `Clappr` architecture, any playback that extends from `HTML5Video` playback will enter the `ready` state as soon as it is rendered but this is not entirely true for the `hlsjs-playback` because it's not guaranteed that an internal instance of the `HLS.JS` module exists.

This PR ensures that if the `hlsjs-playback` is requested to enter in the `ready` state, an internal instance of `HLS.JS` is available.

## Changes

- Call `_setup` method when `_ready` method is called if `this_hls` doesn't exist;
- Cover all `_ready` method code with tests;

## How to test

- Run test page locally without `autoPlay` configured;
- Call on the console tab of your `developer tools` browser: `player.core.activePlayback._hls`;
  - One valid `HLS.JS` instance should be returned.

## A picture/video tells a thousand words

### Before this PR

![Screen Shot 2021-01-29 at 19 10 44](https://user-images.githubusercontent.com/5631063/106332728-1d23be00-6266-11eb-8b79-89dd51903737.png)

### After this PR

![Screen Shot 2021-01-29 at 19 08 51](https://user-images.githubusercontent.com/5631063/106332745-244acc00-6266-11eb-8a50-9b45a978880a.png)

