### PR TITLE
Decouple setup playback process from the load source process

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ var player = new Clappr.Player(
     hlsMinimumDvrSize: 60,
     hlsRecoverAttempts: 16,
     hlsPlayback: {
-      loadSourceBeforePlay: true,
+      preload: true,
     },
     playback: {
       extrapolatedWindowNumSegments: 2,
@@ -96,12 +96,12 @@ var player = new Clappr.Player(
   {
     ...
     hlsPlayback: {
-      loadSourceBeforePlay: true,
+      preload: true,
     },
   });
 ```
 
-#### `hlsPlayback.loadSourceBeforePlay`
+#### `hlsPlayback.preload`
 > Default value: `true`
 
 Configures whether the source should be loaded as soon as the `HLS.JS` internal reference is setup or only after the first play.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ var player = new Clappr.Player(
     hlsUseNextLevel: false,
     hlsMinimumDvrSize: 60,
     hlsRecoverAttempts: 16,
+    hlsPlayback: {
+      loadSourceBeforePlay: true,
+    },
     playback: {
       extrapolatedWindowNumSegments: 2,
       triggerFatalErrorOnResourceDenied: false,
@@ -82,6 +85,26 @@ The `hls.js` have recover approaches for some fatal errors. This option sets the
 > Default value: `false`
 
 If this option is set to true, the playback will triggers fatal error event if decrypt key http response code is greater than or equal to 400. This option is used to attempt to reproduce iOS devices behaviour which internally use html5 video playback.
+
+#### hlsPlayback
+>  Soon (in a new breaking change version), all options related to this playback that are declared in the scope of the `options` object will have to be declared necessarily within this new scope!
+
+Groups all options related directly to `HlsjsPlayback` configs.
+
+```javascript
+var player = new Clappr.Player(
+  {
+    ...
+    hlsPlayback: {
+      loadSourceBeforePlay: true,
+    },
+  });
+```
+
+#### `hlsPlayback.loadSourceBeforePlay`
+> Default value: `true`
+
+Configures whether the source should be loaded as soon as the `HLS.JS` internal reference is setup or only after the first play.
 
 #### hlsjsConfig
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "watch": "rollup --config --watch",
     "bundle-check": "ANALYZE_BUNDLE=true rollup --config",
     "release": "MINIMIZE=true rollup --config",
-    "test": "jest ./src --coverage",
+    "test": "jest ./src --coverage --silent",
     "test:debug": "node --inspect node_modules/.bin/jest ./src --runInBand",
     "test:watch": "jest ./src --watch",
     "lint": "eslint *.js ./src",

--- a/src/hls.js
+++ b/src/hls.js
@@ -109,6 +109,10 @@ export default class HlsjsPlayback extends HTML5Video {
     return this._hls && this._hls.bandwidthEstimate
   }
 
+  get defaultOptions() {
+    return { loadSourceBeforePlay: true }
+  }
+
   static get HLSJS() {
     return HLSJS
   }

--- a/src/hls.js
+++ b/src/hls.js
@@ -424,6 +424,7 @@ export default class HlsjsPlayback extends HTML5Video {
 
   play() {
     !this._hls && this._setup()
+    !this._manifestParsed && !this.options.hlsPlayback.loadSourceBeforePlay && this._hls.loadSource(this.options.src)
 
     super.play()
     this._startTimeUpdateTimer()

--- a/src/hls.js
+++ b/src/hls.js
@@ -110,7 +110,7 @@ export default class HlsjsPlayback extends HTML5Video {
   }
 
   get defaultOptions() {
-    return { loadSourceBeforePlay: true }
+    return { preload: true }
   }
 
   static get HLSJS() {
@@ -168,7 +168,7 @@ export default class HlsjsPlayback extends HTML5Video {
     this._ccTracksUpdated = false
     this._hls && this._hls.destroy()
     this._hls = new HLSJS(assign({}, this.options.playback.hlsjsConfig))
-    this._hls.once(HLSJS.Events.MEDIA_ATTACHED, () => { this.options.hlsPlayback.loadSourceBeforePlay && this._hls.loadSource(this.options.src) })
+    this._hls.once(HLSJS.Events.MEDIA_ATTACHED, () => { this.options.hlsPlayback.preload && this._hls.loadSource(this.options.src) })
     this._hls.on(HLSJS.Events.MANIFEST_PARSED, () => this._manifestParsed = true)
     this._hls.on(HLSJS.Events.LEVEL_LOADED, (evt, data) => this._updatePlaybackType(evt, data))
     this._hls.on(HLSJS.Events.LEVEL_UPDATED, (evt, data) => this._onLevelUpdated(evt, data))
@@ -424,7 +424,7 @@ export default class HlsjsPlayback extends HTML5Video {
 
   play() {
     !this._hls && this._setup()
-    !this._manifestParsed && !this.options.hlsPlayback.loadSourceBeforePlay && this._hls.loadSource(this.options.src)
+    !this._manifestParsed && !this.options.hlsPlayback.preload && this._hls.loadSource(this.options.src)
 
     super.play()
     this._startTimeUpdateTimer()

--- a/src/hls.js
+++ b/src/hls.js
@@ -121,6 +121,7 @@ export default class HlsjsPlayback extends HTML5Video {
     super(...args)
     // backwards compatibility (TODO: remove on 0.3.0)
     this.options.playback = { ...this.options, ...this.options.playback }
+    this.options.hlsPlayback = { ...this.defaultOptions, ...this.options.hlsPlayback }
     this._minDvrSize = typeof (this.options.hlsMinimumDvrSize) === 'undefined' ? 60 : this.options.hlsMinimumDvrSize
     // The size of the start time extrapolation window measured as a multiple of segments.
     // Should be 2 or higher, or 0 to disable. Should only need to be increased above 2 if more than one segment is

--- a/src/hls.js
+++ b/src/hls.js
@@ -163,6 +163,7 @@ export default class HlsjsPlayback extends HTML5Video {
   }
 
   _setup() {
+    this._manifestParsed = false
     this._ccIsSetup = false
     this._ccTracksUpdated = false
     this._hls && this._hls.destroy()

--- a/src/hls.js
+++ b/src/hls.js
@@ -168,6 +168,7 @@ export default class HlsjsPlayback extends HTML5Video {
     this._ccTracksUpdated = false
     this._hls && this._hls.destroy()
     this._hls = new HLSJS(assign({}, this.options.playback.hlsjsConfig))
+    this._hls.once(HLSJS.Events.MEDIA_ATTACHED, () => { this.options.hlsPlayback.loadSourceBeforePlay && this._hls.loadSource(this.options.src) })
     this._hls.on(HLSJS.Events.MANIFEST_PARSED, () => this._manifestParsed = true)
     this._hls.on(HLSJS.Events.LEVEL_LOADED, (evt, data) => this._updatePlaybackType(evt, data))
     this._hls.on(HLSJS.Events.LEVEL_UPDATED, (evt, data) => this._onLevelUpdated(evt, data))

--- a/src/hls.js
+++ b/src/hls.js
@@ -168,7 +168,7 @@ export default class HlsjsPlayback extends HTML5Video {
     this._ccTracksUpdated = false
     this._hls && this._hls.destroy()
     this._hls = new HLSJS(assign({}, this.options.playback.hlsjsConfig))
-    this._hls.once(HLSJS.Events.MEDIA_ATTACHED, () => this._hls.loadSource(this.options.src))
+    this._hls.on(HLSJS.Events.MANIFEST_PARSED, () => this._manifestParsed = true)
     this._hls.on(HLSJS.Events.LEVEL_LOADED, (evt, data) => this._updatePlaybackType(evt, data))
     this._hls.on(HLSJS.Events.LEVEL_UPDATED, (evt, data) => this._onLevelUpdated(evt, data))
     this._hls.on(HLSJS.Events.LEVEL_SWITCHING, (evt,data) => this._onLevelSwitch(evt, data))

--- a/src/hls.js
+++ b/src/hls.js
@@ -423,8 +423,7 @@ export default class HlsjsPlayback extends HTML5Video {
   }
 
   play() {
-    if (!this._hls)
-      this._setup()
+    !this._hls && this._setup()
 
     super.play()
     this._startTimeUpdateTimer()

--- a/src/hls.test.js
+++ b/src/hls.test.js
@@ -10,7 +10,7 @@ describe('HlsjsPlayback', () => {
   })
 
   test('defaultOptions getter returns all the default options values into one object', () => {
-    expect(simplePlaybackMock.defaultOptions).toEqual({ loadSourceBeforePlay: true })
+    expect(simplePlaybackMock.defaultOptions).toEqual({ preload: true })
   })
 
   test('should be able to identify it can play resources independently of the file extension case', () => {
@@ -145,15 +145,15 @@ describe('HlsjsPlayback', () => {
       expect(playback._manifestParsed).toBeFalsy()
     })
 
-    test('calls this._hls.loadSource when MEDIA_ATTACHED event is triggered and hlsPlayback.loadSourceBeforePlay is true', () => {
-      const playback = new HlsjsPlayback({ src: 'http://clappr.io/foo.m3u8', hlsPlayback: { loadSourceBeforePlay: false } })
+    test('calls this._hls.loadSource when MEDIA_ATTACHED event is triggered and hlsPlayback.preload is true', () => {
+      const playback = new HlsjsPlayback({ src: 'http://clappr.io/foo.m3u8', hlsPlayback: { preload: false } })
       playback._setup()
       jest.spyOn(playback._hls, 'loadSource')
       playback._hls.trigger(HLSJS.Events.MEDIA_ATTACHED)
 
       expect(playback._hls.loadSource).not.toHaveBeenCalled()
 
-      playback.options.hlsPlayback.loadSourceBeforePlay = true
+      playback.options.hlsPlayback.preload = true
       playback._setup()
       jest.spyOn(playback._hls, 'loadSource')
       playback._hls.trigger(HLSJS.Events.MEDIA_ATTACHED)
@@ -174,15 +174,15 @@ describe('HlsjsPlayback', () => {
   })
 
   describe('play method', () => {
-    test('calls this._hls.loadSource if _manifestParsed flag and options.hlsPlayback.loadSourceBeforePlay are falsy', () => {
-      const playback = new HlsjsPlayback({ src: 'http://clappr.io/foo.m3u8', hlsPlayback: { loadSourceBeforePlay: true } })
+    test('calls this._hls.loadSource if _manifestParsed flag and options.hlsPlayback.preload are falsy', () => {
+      const playback = new HlsjsPlayback({ src: 'http://clappr.io/foo.m3u8', hlsPlayback: { preload: true } })
       playback._setup()
       jest.spyOn(playback._hls, 'loadSource')
       playback.play()
 
       expect(playback._hls.loadSource).not.toHaveBeenCalled()
 
-      playback.options.hlsPlayback.loadSourceBeforePlay = false
+      playback.options.hlsPlayback.preload = false
       playback._manifestParsed = true
       playback.play()
 

--- a/src/hls.test.js
+++ b/src/hls.test.js
@@ -144,5 +144,32 @@ describe('HlsjsPlayback', () => {
 
       expect(playback._manifestParsed).toBeFalsy()
     })
+
+    test('calls this._hls.loadSource when MEDIA_ATTACHED event is triggered and hlsPlayback.loadSourceBeforePlay is true', () => {
+      const playback = new HlsjsPlayback({ src: 'http://clappr.io/foo.m3u8', hlsjsPlayback: { loadSourceBeforePlay: false } })
+      playback._setup()
+      jest.spyOn(playback._hls, 'loadSource')
+      playback._hls.trigger(HLSJS.Events.MEDIA_ATTACHED)
+
+      expect(playback._hls.loadSource).not.toHaveBeenCalled()
+
+      playback.options.hlsPlayback.loadSourceBeforePlay = true
+      playback._setup()
+      jest.spyOn(playback._hls, 'loadSource')
+      playback._hls.trigger(HLSJS.Events.MEDIA_ATTACHED)
+
+      expect(playback._hls.loadSource).toHaveBeenCalledTimes(1)
+    })
+
+    test('updates _manifestParsed flag value to true if MANIFEST_PARSED event is triggered', () => {
+      const playback = new HlsjsPlayback({ src: 'http://clappr.io/foo.m3u8' })
+
+      expect(playback._manifestParsed).toBeUndefined()
+
+      playback._setup()
+      playback._hls.trigger(HLSJS.Events.MANIFEST_PARSED)
+
+      expect(playback._manifestParsed).toBeTruthy()
+    })
   })
 })

--- a/src/hls.test.js
+++ b/src/hls.test.js
@@ -128,7 +128,7 @@ describe('HlsjsPlayback', () => {
     test('merges defaultOptions with received options.hlsPlayback', () => {
       const options = {
         src: 'http://clappr.io/foo.m3u8',
-        hlsjsPlayback: { foo: 'bar' },
+        hlsPlayback: { foo: 'bar' },
       }
       const playback = new HlsjsPlayback(options)
       expect(playback.options.hlsPlayback).toEqual({ ...options.hlsPlayback, ...playback.defaultOptions })
@@ -146,7 +146,7 @@ describe('HlsjsPlayback', () => {
     })
 
     test('calls this._hls.loadSource when MEDIA_ATTACHED event is triggered and hlsPlayback.loadSourceBeforePlay is true', () => {
-      const playback = new HlsjsPlayback({ src: 'http://clappr.io/foo.m3u8', hlsjsPlayback: { loadSourceBeforePlay: false } })
+      const playback = new HlsjsPlayback({ src: 'http://clappr.io/foo.m3u8', hlsPlayback: { loadSourceBeforePlay: false } })
       playback._setup()
       jest.spyOn(playback._hls, 'loadSource')
       playback._hls.trigger(HLSJS.Events.MEDIA_ATTACHED)
@@ -175,7 +175,7 @@ describe('HlsjsPlayback', () => {
 
   describe('play method', () => {
     test('calls this._hls.loadSource if _manifestParsed flag and options.hlsPlayback.loadSourceBeforePlay are falsy', () => {
-      const playback = new HlsjsPlayback({ src: 'http://clappr.io/foo.m3u8', hlsjsPlayback: { loadSourceBeforePlay: true } })
+      const playback = new HlsjsPlayback({ src: 'http://clappr.io/foo.m3u8', hlsPlayback: { loadSourceBeforePlay: true } })
       playback._setup()
       jest.spyOn(playback._hls, 'loadSource')
       playback.play()

--- a/src/hls.test.js
+++ b/src/hls.test.js
@@ -2,7 +2,7 @@ import { Core, Events } from '@clappr/core'
 import HlsjsPlayback from './hls.js'
 import HLSJS from 'hls.js'
 
-describe('HLS playback', () => {
+describe('HlsjsPlayback', () => {
   test('should be able to identify it can play resources independently of the file extension case', () => {
     jest.spyOn(HLSJS, 'isSupported').mockImplementation(() => true)
     expect(HlsjsPlayback.canPlay('/relative/video.m3u8')).toBeTruthy()

--- a/src/hls.test.js
+++ b/src/hls.test.js
@@ -134,4 +134,15 @@ describe('HlsjsPlayback', () => {
       expect(playback.options.hlsPlayback).toEqual({ ...options.hlsPlayback, ...playback.defaultOptions })
     })
   })
+
+  describe('_setup method', () => {
+    test('sets _manifestParsed flag to false', () => {
+      const playback = new HlsjsPlayback({ src: 'http://clappr.io/foo.m3u8' })
+      expect(playback._manifestParsed).toBeUndefined()
+
+      playback._setup()
+
+      expect(playback._manifestParsed).toBeFalsy()
+    })
+  })
 })

--- a/src/hls.test.js
+++ b/src/hls.test.js
@@ -2,7 +2,17 @@ import { Core, Events } from '@clappr/core'
 import HlsjsPlayback from './hls.js'
 import HLSJS from 'hls.js'
 
+const simplePlaybackMock = new HlsjsPlayback({ src: 'http://clappr.io/video.m3u8' })
+
 describe('HlsjsPlayback', () => {
+  test('have a getter called template', () => {
+    expect(Object.getOwnPropertyDescriptor(Object.getPrototypeOf(simplePlaybackMock), 'defaultOptions').get).toBeTruthy()
+  })
+
+  test('defaultOptions getter returns all the default options values into one object', () => {
+    expect(simplePlaybackMock.defaultOptions).toEqual({ loadSourceBeforePlay: true })
+  })
+
   test('should be able to identify it can play resources independently of the file extension case', () => {
     jest.spyOn(HLSJS, 'isSupported').mockImplementation(() => true)
     expect(HlsjsPlayback.canPlay('/relative/video.m3u8')).toBeTruthy()

--- a/src/hls.test.js
+++ b/src/hls.test.js
@@ -172,4 +172,26 @@ describe('HlsjsPlayback', () => {
       expect(playback._manifestParsed).toBeTruthy()
     })
   })
+
+  describe('play method', () => {
+    test('calls this._hls.loadSource if _manifestParsed flag and options.hlsPlayback.loadSourceBeforePlay are falsy', () => {
+      const playback = new HlsjsPlayback({ src: 'http://clappr.io/foo.m3u8', hlsjsPlayback: { loadSourceBeforePlay: true } })
+      playback._setup()
+      jest.spyOn(playback._hls, 'loadSource')
+      playback.play()
+
+      expect(playback._hls.loadSource).not.toHaveBeenCalled()
+
+      playback.options.hlsPlayback.loadSourceBeforePlay = false
+      playback._manifestParsed = true
+      playback.play()
+
+      expect(playback._hls.loadSource).not.toHaveBeenCalled()
+
+      playback._manifestParsed = false
+      playback.play()
+
+      expect(playback._hls.loadSource).toHaveBeenCalledTimes(1)
+    })
+  })
 })

--- a/src/hls.test.js
+++ b/src/hls.test.js
@@ -43,48 +43,6 @@ describe('HlsjsPlayback', () => {
     expect(playback.tagName).toEqual('audio')
   })
 
-  describe('options backwards compatibility', () => {
-    // backwards compatibility (TODO: remove on 0.3.0)
-    test('should set options.playback as a reference to options if options.playback not set', () => {
-      let options = { src: 'http://clappr.io/video.m3u8' },
-        hls = new HlsjsPlayback(options)
-      expect(hls.options.playback).toEqual(hls.options)
-      options = { src: 'http://clappr.io/video.m3u8', playback: { test: true } }
-      hls = new HlsjsPlayback(options)
-      expect(hls.options.playback.test).toEqual(true)
-    })
-  })
-
-  describe('HlsjsPlayback.js configuration', () => {
-    test('should use hlsjsConfig from playback options', () => {
-      const options = {
-        src: 'http://clappr.io/video.m3u8',
-        playback: {
-          hlsMinimumDvrSize: 1,
-          hlsjsConfig: {
-            someHlsjsOption: 'value'
-          }
-        }
-      }
-      const playback = new HlsjsPlayback(options)
-      playback._setup()
-      expect(playback._hls.config.someHlsjsOption).toEqual('value')
-    })
-
-    test('should use hlsjsConfig from player options as fallback', () => {
-      const options = {
-        src: 'http://clappr.io/video.m3u8',
-        hlsMinimumDvrSize: 1,
-        hlsjsConfig: {
-          someHlsjsOption: 'value'
-        }
-      }
-      const playback = new HlsjsPlayback(options)
-      playback._setup()
-      expect(playback._hls.config.someHlsjsOption).toEqual('value')
-    })
-  })
-
   test('should trigger a playback error if source load failed', () => {
     jest.spyOn(window.HTMLMediaElement.prototype, 'play').mockImplementation(() => {})
     let resolveFn = undefined
@@ -136,5 +94,44 @@ describe('HlsjsPlayback', () => {
     playback.currentLevel = 1
     expect(playback.currentLevel).toEqual(1)
     expect(playback._hls.currentLevel).toEqual(1)
+  })
+
+  describe('constructor', () => {
+    test('should use hlsjsConfig from playback options', () => {
+      const options = {
+        src: 'http://clappr.io/video.m3u8',
+        playback: {
+          hlsMinimumDvrSize: 1,
+          hlsjsConfig: {
+            someHlsjsOption: 'value'
+          }
+        }
+      }
+      const playback = new HlsjsPlayback(options)
+      playback._setup()
+      expect(playback._hls.config.someHlsjsOption).toEqual('value')
+    })
+
+    test('should use hlsjsConfig from player options as fallback', () => {
+      const options = {
+        src: 'http://clappr.io/video.m3u8',
+        hlsMinimumDvrSize: 1,
+        hlsjsConfig: {
+          someHlsjsOption: 'value'
+        }
+      }
+      const playback = new HlsjsPlayback(options)
+      playback._setup()
+      expect(playback._hls.config.someHlsjsOption).toEqual('value')
+    })
+
+    test('merges defaultOptions with received options.hlsPlayback', () => {
+      const options = {
+        src: 'http://clappr.io/foo.m3u8',
+        hlsjsPlayback: { foo: 'bar' },
+      }
+      const playback = new HlsjsPlayback(options)
+      expect(playback.options.hlsPlayback).toEqual({ ...options.hlsPlayback, ...playback.defaultOptions })
+    })
   })
 })


### PR DESCRIPTION
## Summary

The code that creates an instance of `HLS.JS` also parses the manifest automatically. To avoid this behavior when is necessary, this PR creates a new configuration (`options.hlsPlayback.preload`) for parsing happens only after a `play` command is received.

Also, configure `Jest` to avoid noise logs on test output.

## Changes

- Create new options scope `options.hlsPlayback`;
- Create new option `options.hlsPlayback.preload`;
-  Add docs about the new options;
- Create `defaultOptions` getter representing `options.hlsPlayback` initial values;
- Merge received `options.hlsPlayback` with `defaultOptions`;
- Create new flag `_manifestParsed`;
- Listen `MANIFEST_PARSED` `HLS.JS` event to set value `true` on `_manifestParsed` flag;
- Set `false` on `_manifestParsed` flag when `_setup` method is called;
- Load source at first play when it's not load at `_setup` process;
- Configure `Jest` to run with `--silent` flag;
- Delete test case covering logic from `HTML5Video` playback (it's already covered on `@clappr/core`);

## How to test

#### With `options.hlsPlayback.preload` as `false`:

- Attatch Clappr with `HlsjsPlayback`;
- Check the `network` tab on your browser `developer tools`;
  - No one manifest (`.m3u8`) or video chunk (`.ts`) should have be download.

---

#### With `options.hlsPlayback.preload` as `true`:

- Attatch Clappr with `HlsjsPlayback`;
- Check the `network` tab on your browser `developer tools`;
  - The manifest (`.m3u8`) and video chunks (`.ts`) should have be download.

## A picture/video tells a thousand words

### Before this PR

https://user-images.githubusercontent.com/5631063/106394804-57639b80-63dd-11eb-9953-cfa1b9504c52.mov

### After this PR

#### With `options.hlsPlayback.preload` as `true`:

https://user-images.githubusercontent.com/5631063/106394827-677b7b00-63dd-11eb-8991-e4e96d986a55.mov

---

#### With `options.hlsPlayback.preload` as `false`:

https://user-images.githubusercontent.com/5631063/106394835-76622d80-63dd-11eb-8db5-f37ae628fd82.mov
