### PR TITLE
Custom listeners for HLS.js events

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ var player = new Clappr.Player(
     hlsPlayback: {
       ...
       customListeners: [
-        { eventName: 'FRAG_LOADED', callback: (event, data) => { console.log('>>>>>> data: ', data) }, once: true }
+        // "hlsFragLoaded" is the value of HlsjsPlayback.HLSJS.Events.FRAG_LOADED constant.
+        { eventName: 'hlsFragLoaded', callback: (event, data) => { console.log('>>>>>> data: ', data) }, once: true }
       ],
     },
   });
@@ -127,7 +128,7 @@ var player = new Clappr.Player(
 
 The listener object parameters are:
 
-* `eventName`: A valid event name of `HLS.JS` [events API](https://github.com/video-dev/hls.js/blob/master/docs/API.md#runtime-events);
+* `eventName`: A valid event name of `hls.js` [events API](https://github.com/video-dev/hls.js/blob/master/docs/API.md#runtime-events);
 * `callback`: The callback that should be called  when the event listened happen.
 * `once`: Flag to configure if the listener needs to be valid just for one time.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ var player = new Clappr.Player(
     hlsRecoverAttempts: 16,
     hlsPlayback: {
       preload: true,
+      customListeners: [],
     },
     playback: {
       extrapolatedWindowNumSegments: 2,
@@ -97,6 +98,7 @@ var player = new Clappr.Player(
     ...
     hlsPlayback: {
       preload: true,
+      customListeners: [],
     },
   });
 ```
@@ -105,6 +107,29 @@ var player = new Clappr.Player(
 > Default value: `true`
 
 Configures whether the source should be loaded as soon as the `HLS.JS` internal reference is setup or only after the first play.
+
+#### `hlsPlayback.customListeners`
+
+An array of listeners object with specific parameters to add on `HLS.JS` instance.
+
+```javascript
+var player = new Clappr.Player(
+  {
+    ...
+    hlsPlayback: {
+      ...
+      customListeners: [
+        { eventName: 'FRAG_LOADED', callback: (event, data) => { console.log('>>>>>> data: ', data) }, once: true }
+      ],
+    },
+  });
+```
+
+The listener object parameters are:
+
+* `eventName`: A valid event name of `HLS.JS` [events API](https://github.com/video-dev/hls.js/blob/master/docs/API.md#runtime-events);
+* `callback`: The callback that should be called  when the event listened happen.
+* `once`: Flag to configure if the listener needs to be valid just for one time.
 
 #### hlsjsConfig
 

--- a/src/hls.js
+++ b/src/hls.js
@@ -193,14 +193,14 @@ export default class HlsjsPlayback extends HTML5Video {
     this.customListeners.forEach(item => {
       const requestedEventName = item.eventName
       const typeOfListener = item.once ? 'once': 'on'
-      HLSJS.Events[`${requestedEventName}`] && this._hls[`${typeOfListener}`](HLSJS.Events[`${requestedEventName}`], item.callback)
+      requestedEventName && this._hls[`${typeOfListener}`](requestedEventName, item.callback)
     })
   }
 
   unbindCustomListeners() {
     this.customListeners.forEach(item => {
       const requestedEventName = item.eventName
-      HLSJS.Events[`${requestedEventName}`] && this._hls.off(HLSJS.Events[`${requestedEventName}`], item.callback)
+      requestedEventName && this._hls.off(requestedEventName, item.callback)
     })
   }
 

--- a/src/hls.js
+++ b/src/hls.js
@@ -194,6 +194,16 @@ export default class HlsjsPlayback extends HTML5Video {
       HLSJS.Events[`${requestedEventName}`] && this._hls[`${typeOfListener}`](HLSJS.Events[`${requestedEventName}`], item.callback)
     })
   }
+
+  unbindCustomListeners() {
+    this.options.hlsPlayback &&
+    this.options.hlsPlayback.customListeners &&
+    this.options.hlsPlayback.customListeners.forEach(item => {
+      const requestedEventName = item.eventName
+      HLSJS.Events[`${requestedEventName}`] && this._hls.off(HLSJS.Events[`${requestedEventName}`], item.callback)
+    })
+  }
+
   _onFragmentParsingMetadata(evt, data) {
     this.trigger(Events.Custom.PLAYBACK_FRAGMENT_PARSING_METADATA, { evt, data })
   }

--- a/src/hls.js
+++ b/src/hls.js
@@ -182,6 +182,15 @@ export default class HlsjsPlayback extends HTML5Video {
     this._hls.attachMedia(this.el)
   }
 
+  bindCustomListeners() {
+    this.options.hlsPlayback &&
+    this.options.hlsPlayback.customListeners &&
+    this.options.hlsPlayback.customListeners.forEach(item => {
+      const requestedEventName = item.eventName
+      const typeOfListener = item.once ? 'once': 'on'
+      HLSJS.Events[`${requestedEventName}`] && this._hls[`${typeOfListener}`](HLSJS.Events[`${requestedEventName}`], item.callback)
+    })
+  }
   _onFragmentParsingMetadata(evt, data) {
     this.trigger(Events.Custom.PLAYBACK_FRAGMENT_PARSING_METADATA, { evt, data })
   }

--- a/src/hls.js
+++ b/src/hls.js
@@ -113,6 +113,10 @@ export default class HlsjsPlayback extends HTML5Video {
     return { preload: true }
   }
 
+  get customListeners() {
+    return this.options.hlsPlayback && this.options.hlsPlayback.customListeners || []
+  }
+
   static get HLSJS() {
     return HLSJS
   }
@@ -186,9 +190,7 @@ export default class HlsjsPlayback extends HTML5Video {
   }
 
   bindCustomListeners() {
-    this.options.hlsPlayback &&
-    this.options.hlsPlayback.customListeners &&
-    this.options.hlsPlayback.customListeners.forEach(item => {
+    this.customListeners.forEach(item => {
       const requestedEventName = item.eventName
       const typeOfListener = item.once ? 'once': 'on'
       HLSJS.Events[`${requestedEventName}`] && this._hls[`${typeOfListener}`](HLSJS.Events[`${requestedEventName}`], item.callback)
@@ -196,9 +198,7 @@ export default class HlsjsPlayback extends HTML5Video {
   }
 
   unbindCustomListeners() {
-    this.options.hlsPlayback &&
-    this.options.hlsPlayback.customListeners &&
-    this.options.hlsPlayback.customListeners.forEach(item => {
+    this.customListeners.forEach(item => {
       const requestedEventName = item.eventName
       HLSJS.Events[`${requestedEventName}`] && this._hls.off(HLSJS.Events[`${requestedEventName}`], item.callback)
     })

--- a/src/hls.js
+++ b/src/hls.js
@@ -179,6 +179,9 @@ export default class HlsjsPlayback extends HTML5Video {
     this._hls.on(HLSJS.Events.ERROR, (evt, data) => this._onHLSJSError(evt, data))
     this._hls.on(HLSJS.Events.SUBTITLE_TRACK_LOADED, (evt, data) => this._onSubtitleLoaded(evt, data))
     this._hls.on(HLSJS.Events.SUBTITLE_TRACKS_UPDATED, () => this._ccTracksUpdated = true)
+
+    this.bindCustomListeners()
+
     this._hls.attachMedia(this.el)
   }
 

--- a/src/hls.test.js
+++ b/src/hls.test.js
@@ -22,7 +22,7 @@ describe('HlsjsPlayback', () => {
     const playback = new HlsjsPlayback({
       src: 'http://clappr.io/foo.m3u8',
       hlsPlayback: {
-        customListeners: [{ eventName: 'MEDIA_ATTACHING', callback: cb }]
+        customListeners: [{ eventName: 'hlsMediaAttaching', callback: cb }]
       }
     })
     expect(playback.customListeners).toEqual(playback.options.hlsPlayback.customListeners)
@@ -268,7 +268,7 @@ describe('HlsjsPlayback', () => {
       const playback = new HlsjsPlayback({
         src: 'http://clappr.io/foo.m3u8',
         hlsPlayback: {
-          customListeners: [{ eventName: 'MEDIA_ATTACHING', callback: cb }]
+          customListeners: [{ eventName: HLSJS.Events.MEDIA_ATTACHING, callback: cb }]
         }
       })
       playback._setup()
@@ -305,7 +305,7 @@ describe('HlsjsPlayback', () => {
       const playback = new HlsjsPlayback({
         src: 'http://clappr.io/foo.m3u8',
         hlsPlayback: {
-          customListeners: [{ eventName: 'MEDIA_ATTACHING', callback: cb, once: true }]
+          customListeners: [{ eventName: HLSJS.Events.MEDIA_ATTACHING, callback: cb, once: true }]
         }
       })
       playback._setup()
@@ -324,7 +324,7 @@ describe('HlsjsPlayback', () => {
       const playback = new HlsjsPlayback({
         src: 'http://clappr.io/foo.m3u8',
         hlsPlayback: {
-          customListeners: [{ eventName: 'FRAG_LOADED', callback: cb }]
+          customListeners: [{ eventName: 'hlsFragLoaded', callback: cb }]
         }
       })
       playback._setup()

--- a/src/hls.test.js
+++ b/src/hls.test.js
@@ -302,4 +302,21 @@ describe('HlsjsPlayback', () => {
       expect(cb).toHaveBeenCalledTimes(1)
     })
   })
+
+  describe('unbindCustomListeners method', () => {
+    test('remove listeners for each item configured on customListeners array', () => {
+      const cb = jest.fn()
+      const playback = new HlsjsPlayback({
+        src: 'http://clappr.io/foo.m3u8',
+        hlsPlayback: {
+          customListeners: [{ eventName: 'FRAG_LOADED', callback: cb }]
+        }
+      })
+      playback._setup()
+      playback.unbindCustomListeners()
+      playback._hls.trigger(HLSJS.Events.FRAG_LOADED)
+
+      expect(cb).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/src/hls.test.js
+++ b/src/hls.test.js
@@ -171,6 +171,14 @@ describe('HlsjsPlayback', () => {
 
       expect(playback._manifestParsed).toBeTruthy()
     })
+
+    test('calls bindCustomListeners method', () => {
+      const playback = new HlsjsPlayback({ src: 'http://clappr.io/foo.m3u8' })
+      jest.spyOn(playback, 'bindCustomListeners')
+      playback._setup()
+
+      expect(playback.bindCustomListeners).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('_ready method', () => {

--- a/src/hls.test.js
+++ b/src/hls.test.js
@@ -5,12 +5,27 @@ import HLSJS from 'hls.js'
 const simplePlaybackMock = new HlsjsPlayback({ src: 'http://clappr.io/video.m3u8' })
 
 describe('HlsjsPlayback', () => {
-  test('have a getter called template', () => {
+  test('have a getter called defaultOptions', () => {
     expect(Object.getOwnPropertyDescriptor(Object.getPrototypeOf(simplePlaybackMock), 'defaultOptions').get).toBeTruthy()
   })
 
   test('defaultOptions getter returns all the default options values into one object', () => {
     expect(simplePlaybackMock.defaultOptions).toEqual({ preload: true })
+  })
+
+  test('have a getter called customListeners', () => {
+    expect(Object.getOwnPropertyDescriptor(Object.getPrototypeOf(simplePlaybackMock), 'customListeners').get).toBeTruthy()
+  })
+
+  test('customListeners getter returns all configured custom listeners for each hls.js event', () => {
+    const cb = () => {}
+    const playback = new HlsjsPlayback({
+      src: 'http://clappr.io/foo.m3u8',
+      hlsPlayback: {
+        customListeners: [{ eventName: 'MEDIA_ATTACHING', callback: cb }]
+      }
+    })
+    expect(playback.customListeners).toEqual(playback.options.hlsPlayback.customListeners)
   })
 
   test('should be able to identify it can play resources independently of the file extension case', () => {

--- a/src/hls.test.js
+++ b/src/hls.test.js
@@ -238,4 +238,60 @@ describe('HlsjsPlayback', () => {
       expect(playback._hls.loadSource).toHaveBeenCalledTimes(1)
     })
   })
+
+  describe('bindCustomListeners method', () => {
+    test('creates listeners for each item configured on customListeners array', () => {
+      const cb = jest.fn()
+      const playback = new HlsjsPlayback({
+        src: 'http://clappr.io/foo.m3u8',
+        hlsPlayback: {
+          customListeners: [{ eventName: 'MEDIA_ATTACHING', callback: cb }]
+        }
+      })
+      playback._setup()
+
+      expect(cb).toHaveBeenCalledTimes(1)
+
+      playback._hls.trigger(HLSJS.Events.MEDIA_ATTACHING)
+
+      expect(cb).toHaveBeenCalledTimes(2)
+    })
+
+    test('don\'t add one listener without a valid configuration', () => {
+      const cb = jest.fn()
+      const playback = new HlsjsPlayback({ src: 'http://clappr.io/foo.m3u8' })
+      playback._setup()
+
+      expect(cb).not.toHaveBeenCalled()
+
+      playback.options.hlsPlayback = {}
+
+      expect(cb).not.toHaveBeenCalled()
+
+      playback.options.hlsPlayback.customListeners = []
+
+      expect(cb).not.toHaveBeenCalled()
+
+      playback.options.hlsPlayback.customListeners.push([{ eventName: 'invalid_name', callback: cb }])
+
+      expect(cb).not.toHaveBeenCalled()
+    })
+
+    test('adds a listener for one time when the customListeners array item is configured with the "once" param', () => {
+      const cb = jest.fn()
+      const playback = new HlsjsPlayback({
+        src: 'http://clappr.io/foo.m3u8',
+        hlsPlayback: {
+          customListeners: [{ eventName: 'MEDIA_ATTACHING', callback: cb, once: true }]
+        }
+      })
+      playback._setup()
+
+      expect(cb).toHaveBeenCalledTimes(1)
+
+      playback._hls.trigger(HLSJS.Events.MEDIA_ATTACHING)
+
+      expect(cb).toHaveBeenCalledTimes(1)
+    })
+  })
 })


### PR DESCRIPTION
#### This PR depends on #14 to works with all `HLS.js` events (including events triggered before the media started).

## Summary

This PR creates one new option (`hlsPlayback.customListeners`) to add the possibility to create listeners for `HLS.js` events. Also, creates the possibility to remove those custom listeners.

## Changes

- Creates new option `hlsPlayback.customListeners`;
- Add Docs for the new option;
- Creates `bindCustomListeners` method;
- Creates `unbindCustomListeners` method;
- Cover all new code with tests;

## How to test

#### Testing listeners to listen each time the select event is triggered:

- Configure one custom listeners for one `HLS.js` event on the`hlsPlayback.customListeners` array;
  - E.g.: `{ eventName: 'FRAG_LOADED', callback: (evt, data) => { console.log(evt, data) } }`
- Run the project locally;
- Open the `console` tab of your browser `developer tools`;
  - The configured console on the callback should be printed on every time the selected event is triggered.

#### Testing listeners to listen just one time:

- Configure one custom listeners for one `HLS.js` event on the`hlsPlayback.customListeners` array with the `once` option;
  - E.g.: `{ eventName: 'FRAG_LOADED', callback: (evt, data) => { console.log(evt, data) }, once: true }`
- Run the project locally;
- Open the `console` tab of your browser `developer tools`;
  - The configured console on the callback should be printed just one time for the selected event.

#### Testing `unbindCustomListeners`:

- Configure one custom listeners for one `HLS.js` event on the`hlsPlayback.customListeners` array;
  - E.g.: `{ eventName: 'FRAG_LOADED', callback: (evt, data) => { console.log(evt, data) } }`
- Run the project locally;
- Open the `console` tab of your browser `developer tools`;
  - The configured console on the callback should be printed.
- Call `unbindCustomListeners` method;
  - E.g.: Call on the `console` tab of your browser `developer tools` -> `player.core.activePlayback._hls.unbindCustomListeners()`.
  - The configured log on the callback should not be printed anymore.

## A picture/video tells a thousand words

### After this PR

#### Testing listeners to listen each time the select event is triggered:

https://user-images.githubusercontent.com/5631063/106403614-59921e00-640e-11eb-901e-3e614f8d99ca.mov

---

#### Testing listeners to listen just one time:

https://user-images.githubusercontent.com/5631063/106403631-6adb2a80-640e-11eb-9620-7cf80a9d3cde.mov

---

#### Testing `unbindCustomListeners`:

https://user-images.githubusercontent.com/5631063/106403705-c1e0ff80-640e-11eb-956d-ba479fdaeb72.mov
