### PR TITLE
Add getters related to Latency information

### DIFF
--- a/src/hls.js
+++ b/src/hls.js
@@ -40,6 +40,14 @@ export default class HlsjsPlayback extends HTML5Video {
       this._hls.currentLevel = this._currentLevel
   }
 
+  get latency() {
+    return this._hls.latency
+  }
+
+  get currentProgramDateTime() {
+    return this._hls.playingDate
+  }
+
   get _startTime() {
     if (this._playbackType === Playback.LIVE && this._playlistType !== 'EVENT')
       return this._extrapolatedStartTime


### PR DESCRIPTION
## Summary

This PR implements two new getters to `HlsjsPlayback` that retrieve info related to a live video's latency and its current playing date (the Program Date Time value attributed to the ongoing stream fragment).

In order for this to be retrieved, the following PR must also be implemented: https://github.com/clappr/clappr-core/pull/117

