### PR TITLE
Add getter to current timestamp

### DIFF
--- a/src/hls.js
+++ b/src/hls.js
@@ -127,6 +127,15 @@ export default class HlsjsPlayback extends HTML5Video {
     return this.options.src
   }
 
+  get currentTimestamp() {
+    if (!this._currentFragment) return null
+    const startTime = this._currentFragment.programDateTime
+    const playbackTime = this.el.currentTime
+    const playTimeOffSet = playbackTime - this._currentFragment.start
+    const currentTimestampInMs = startTime + playTimeOffSet * 1000
+    return currentTimestampInMs / 1000
+  }
+
   static get HLSJS() {
     return HLSJS
   }
@@ -635,6 +644,7 @@ export default class HlsjsPlayback extends HTML5Video {
   }
 
   _onFragmentChanged(evt, data) {
+    this._currentFragment = data.frag
     this.trigger(Events.Custom.PLAYBACK_FRAGMENT_CHANGED, data)
   }
 

--- a/src/hls.test.js
+++ b/src/hls.test.js
@@ -346,4 +346,27 @@ describe('HlsjsPlayback', () => {
       expect(cb).not.toHaveBeenCalled()
     })
   })
+
+  describe('currentTimestamp', () => {
+    it('returns the fragment time plus the current playback time', () => {
+      const fragmentMock = {
+        frag: {
+          programDateTime: 1556663040000, // 'Tue Apr 30 2019 19:24:00'
+          start: 0,
+        }
+      }
+      const playback = new HlsjsPlayback({ src: 'http://clappr.io/foo.m3u8' })
+      playback.el.currentTime = 5
+      playback._setup()
+      playback.unbindCustomListeners()
+      playback._hls.trigger(HLSJS.Events.FRAG_CHANGED, fragmentMock)
+      expect(playback.currentTimestamp).toBe(1556663045) // 'Tue Apr 30 2019 19:24:05'
+    })
+
+    it('returns null if the playback does not have a fragment', () => {
+      const playback = new HlsjsPlayback({ src: 'http://clappr.io/foo.m3u8' })
+      playback._setup()
+      expect(playback.currentTimestamp).toBe(null)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

This MR implements a new getter `currentTimestamp` originated by the `PLAYBACK_FRAGMENT_CHANGED` event. This makes it possible to access the current timestamp of the fragment reproduced by the playback.

### Changes

- `hls.js`: add `currentTimestamp` getter;
- `hls.test.js`: add testes to `currentTimestamp` getter.